### PR TITLE
fix: deboostrap commands md formatting

### DIFF
--- a/lessons/02-crafting-containers-by-hand/C-namespaces.md
+++ b/lessons/02-crafting-containers-by-hand/C-namespaces.md
@@ -40,24 +40,21 @@ So let's create a chroot'd environment now that's isolated using namespaces usin
 
 **NOTE**: This next command downloads about 150MB and takes at least a few minutes to run. Unlike Docker images, this will redownload it _every_ time you run it and does no caching.
 
-````bash
+```bash
 # from our chroot'd environment if you're still running it, if not skip this
 exit
 
 ## Install debootstrap
-
-```bash
 apt-get update -y
 apt-get install debootstrap -y
 debootstrap --variant=minbase jammy /better-root
 
 # head into the new namespace'd, chroot'd environment
-
 unshare --mount --uts --ipc --net --pid --fork --user --map-root-user chroot /better-root bash # this also chroot's for us
 mount -t proc none /proc # process namespace
 mount -t sysfs none /sys # filesystem
 mount -t tmpfs none /tmp # filesystem
-````
+```
 
 This will create a new environment that's isolated on the system with its own PIDs, mounts (like storage and volumes), and network stack. Now we can't see any of the processes!
 


### PR DESCRIPTION
Before
Notice ```bash printed
<img width="400" alt="Screenshot 2024-05-26 at 13 23 05" src="https://github.com/btholt/complete-intro-to-containers-v2/assets/5403694/010f66ab-ec99-42ba-99b1-004784855148">

After
<img width="410" alt="Screenshot 2024-05-26 at 13 23 31" src="https://github.com/btholt/complete-intro-to-containers-v2/assets/5403694/93ee5e4c-234e-4d63-9d3e-b029c2817542">
