### PR TITLE
feat: make TOC sections clickable

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { getLessons } from "../data/lesson";
 
@@ -8,6 +9,7 @@ import getCourseConfig from "../data/course";
 
 export default function Lessons({ sections }) {
   const courseInfo = getCourseConfig();
+  const router = useRouter()
   return (
     <>
       <Head>
@@ -61,7 +63,7 @@ export default function Lessons({ sections }) {
             <ol className="sections-name">
               {sections.map((section) => (
                 <li key={section.slug}>
-                  <div className="lesson-details">
+                  <div className="lesson-details" onClickCapture={() => router.push(section.lessons[0].fullSlug)}>
                     <div className="lesson-preface">
                       <i className={`fas fa-${section.icon}`}></i>
                     </div>


### PR DESCRIPTION
### Current
When moving a cursor over section, a triangle in corner reacts.
This may suggest that section is clickable but atm it's not.

![hover-before](https://github.com/user-attachments/assets/90b66fca-b7ec-4bd4-9a88-38aa39bcbaf5)

### After
When section is clicked go to the first lesson of section.

![toc-sections-after](https://github.com/user-attachments/assets/d1125144-39b0-464f-a3c3-ffb9cb428208)

### Todo
- [x] go to first lesson on section click
- [x] don't disturb clicking on link to a specific lesson
- [x] manually test

`OnClickCaputure` is used instead of `OnClick` to not interfere with a click on one of lessons links.
