### PR TITLE
fix: delete no used environment API_URL in docker-compose.yml file

### DIFF
--- a/lessons/07-multi-container-projects/A-docker-compose.md
+++ b/lessons/07-multi-container-projects/A-docker-compose.md
@@ -41,8 +41,6 @@ services:
     image: mongo:7
   web:
     build: web
-    environment:
-      API_URL: http://api:8080
     ports:
       - "8081:80"
 ```
@@ -55,7 +53,7 @@ The one interesting one here is the `links` field. In this one we're saying that
 
 The `db` container is pretty simple: it's just the `mongo` container from Docker Hub. This is actually smart enough to expose 27017 as the port and to make a volume to keep the data around between restarts so we don't actually have to do anything for that. If you needed any other containers, you'd just put them here in services.
 
-We then have a frontend React.js app that is being built by Parcel.js and served by NGINX. Only interesting thing is we are serving API traffic to the api URL which will go over the internal Docker Compose network
+We then have a frontend React.js app that is being built by Parcel.js and served by NGINX.
 
 There's a lot more to compose files than what I've shown you here but I'll let you explore that on your own time. [Click here][compose] to see the docs to see what else is possible.
 


### PR DESCRIPTION
 `API_URL` defined in [docker-compose/docker-compose.yml](https://raw.githubusercontent.com/btholt/project-files-for-complete-intro-to-containers-v2/main/docker-compose/docker-compose.yml)  is intended to be used in [docker-compose/web/src/web.jsx](https://github.com/btholt/project-files-for-complete-intro-to-containers-v2/raw/main/docker-compose/web/src/web.jsx).

    ```yml
    environment:
        API_URL: http://api:80808
    ```
 
    ```javascript
    const API_URL = process.env.API_URL || "http://localhost:8080";
    ```
`process.env.API_URL` can only be accessed during build stage. These is no code in container can get API_URL. The actual api domain visited from broswer is `http://localhost:8080`.

![image](https://github.com/user-attachments/assets/b80b8cea-db02-40cd-a2cc-b4145d5ec951)

The easiest fix is to delete the API_URL environment from [docker-compose/docker-compose.yml](https://raw.githubusercontent.com/btholt/project-files-for-complete-intro-to-containers-v2/main/docker-compose/docker-compose.yml).

Very excited to watch *complete-intro-to-containers-v2*. It's the best container tutorial I've learned. Thank you, Brian.